### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       endpoints:
         - exposure: public
           name: nodejs


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

Related issue: https://github.com/eclipse/che/issues/21979

![Screenshot from 2023-03-21 17-02-52](https://user-images.githubusercontent.com/1271546/226648328-27c06874-44d1-4eed-8ebf-33b87c4408d4.png)
