### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -29,7 +29,7 @@ commands:
       label: "Build the app"
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: "yarn build"
+      commandLine: "NODE_OPTIONS=--openssl-legacy-provider yarn build"
       group:
         kind: build
         isDefault: true
@@ -39,7 +39,7 @@ commands:
       label: "Run the web app"
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: "yarn start"
+      commandLine: "NODE_OPTIONS=--openssl-legacy-provider yarn start"
       group:
         kind: run
 
@@ -48,6 +48,6 @@ commands:
       label: "Launch tests"
       component: tools
       workingDir: ${PROJECT_SOURCE}
-      commandLine: "yarn test"
+      commandLine: "NODE_OPTIONS=--openssl-legacy-provider yarn test"
       group:
         kind: test

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -8,7 +8,7 @@ components:
       endpoints:
         - exposure: public
           name: nodejs
-          protocol: http
+          protocol: https
           targetPort: 3000
       memoryLimit: 1G
       mountSources: true


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_59_01](https://github.com/che-samples/react-web-app/assets/1271546/c15d74f2-5337-4702-9390-f3ae0d5f91f5)


Related issue: https://issues.redhat.com/browse/CRW-5377